### PR TITLE
Remove `// component imports` comment

### DIFF
--- a/src/Components/IntroText.js
+++ b/src/Components/IntroText.js
@@ -1,6 +1,4 @@
 import React from 'react';
-
-// component imports
 import Typed from 'typed.js';
 
 // asset imports


### PR DESCRIPTION
- `Typed` is actually from the `typed.js` library which I mistakenly thought of as a component import and therefore, grouped it under `// component imports` comment. So removing that now.